### PR TITLE
Match case of lib file.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,1 @@
-
-module.exports = require('./lib/twitter');
+module.exports = require('./lib/Twitter');


### PR DESCRIPTION
For case sensitive filesystems it was unable to include the module, since the filenames did not match.
