### PR TITLE
Return header info about API limits

### DIFF
--- a/lib/Twitter.js
+++ b/lib/Twitter.js
@@ -158,7 +158,12 @@ Twitter.prototype.doRequest = function (url, error, success) {
     this.oauth.get(url, this.accessToken, this.accessTokenSecret, function (err, body, response) {
         console.log('URL [%s]', url);
         if (!err && response.statusCode == 200) {
-            success(body);
+            limits = {
+                "x-rate-limit-limit": response.headers['x-rate-limit-limit'],
+                "x-rate-limit-remaining": response.headers['x-rate-limit-remaining'],
+                "x-rate-limit-reset": response.headers['x-rate-limit-reset'],
+            };
+            success(body, limits);
         } else {
             error(err, response, body);
         }


### PR DESCRIPTION
I found it important for my use case to have the rate limits available to understand when and how often I can keep making queries.
This can be useful or just ignored in the success function. 