### PR TITLE
fix qs dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "version":"0.0.6",
     "directories" : { "lib": "./lib" },
     "dependencies":{
-        "qs": "*",
+        "qs": "5.2.0",
         "oauth": "*"
     }
 }


### PR DESCRIPTION
I need to use fixed qs package to avoid error below:

node_modules/twitter-node-client/node_modules/qs/lib/index.js:5
const Stringify = require('./stringify');
^^^^^
error: Fatal error: SyntaxError: Use of const in strict mode.