### PR TITLE
Adding all 2xx status codes to success for doPost.

### DIFF
--- a/lib/Twitter.js
+++ b/lib/Twitter.js
@@ -211,7 +211,7 @@ Twitter.prototype.doPost = function (url, post_body, error, success) {
     //(url, oauth_token, oauth_token_secret, post_body, post_content_type, callback 
     this.oauth.post(url, this.accessToken, this.accessTokenSecret, post_body, "application/x-www-form-urlencoded", function (err, body, response) {
         if (DEBUG) console.log('URL [%s]', url);
-        if (!err && response.statusCode == 200) {
+        if (!err && response.statusCode >= 200 && response.statusCode < 300) {
             success(body);
         } else {
             error(err, response, body);


### PR DESCRIPTION
https://dev.twitter.com/rest/reference/post/media/metadata/create

Trying to use the media upload I discovered this bug. According to the docs this post endpoint returns 2xx status code. In this case for the INIT it was returning a 202. This made it go into the error. 
